### PR TITLE
Add a configurable claim fee

### DIFF
--- a/test/harnesses/GovernanceStakerHarness.sol
+++ b/test/harnesses/GovernanceStakerHarness.sol
@@ -22,7 +22,10 @@ contract GovernanceStakerHarness is GovernanceStaker {
   )
     GovernanceStaker(_rewardsToken, _stakeToken, _earningPowerCalculator, _maxBumpTip, _admin)
     EIP712(_name, "1")
-  {}
+  {
+    MAX_CLAIM_FEE = 1e18;
+    _setClaimFeeParameters(ClaimFeeParameters({feeAmount: 0, feeCollector: address(0)}));
+  }
 
   function exposed_useDepositId() external returns (DepositIdentifier _depositId) {
     _depositId = _useDepositId();


### PR DESCRIPTION
The claim fee is intentionally set as a fixed amount. The primary purpose of this
fee is to act as a deterrent to "deposit sybiling", whereby a staker might spread
funds out across many deposits in an attempt to reduce the liklihood or frequency
of being "bumped" if his earning power decreases. Allowing the DAO to set a small,
fixed fee would decrease the effective yield of small deposits without materially
impacting a normal user.