### PR TITLE
Rename contracts to simply use the name Staker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,44 @@
-***DISCLAIMER: This codebase is not yet audited***
+# Staker
 
-# Governance Staking
-
-Governance Staking rewards a DAO's tokenholders for participating in governance. This staking system distributes rewards to tokenholders whose tokens are active in governance. Rewards generally come from the DAO, funded by protocol revenue and/or issuance of the native token from the treasury.
+Staker is a flexible, configurable staking contract. Staker makes it easy to distribute onchain staking rewards for any ERC20 token.
 
 ## How it works:
 
-- The DAO decides how stakers can be eligible for rewards. The DAO sets up an oracle to put eligiblity scores onchain.
-- Tokenholders stake their tokens. There is no delay to stake or unstake. Stakers set a claimer for their reward, such as themselves.
-- The DAO sends rewards into its Governance Staking.
-- Governance Staking distributes the rewards over time. Each staker's reward is proportional to their staked balance over time.
+### 1. Deploy and configurate a Staker
+- Staker is deployed with a single staking token
+- Staker is deployed with an admin, such as a DAO.
+- Staker is configured to distribute one or more reward tokens
+
+### 2. Tokenholders stake
+- Tokenholders of the staking token can deposit those tokens in Staker.
+- There is no delay to deposit or withdraw.
+- If the staking token is a governance token, depositors can delegate their staked tokens' voting power to themselves or someone else
+- The depositor sets a claimer who can claim the staking rewards, such as themselves or someone else.
+
+### 3. Staker distributes rewards
+- The admin sends rewards into Staker.
+- Optionally, the admin sets eligibility criteria for rewards.
+- Staker distributes those rewards over time.
+- Each tokenholder's reward is proportional to their staked balance over time.
 - Claimers can claim their accrued rewards at any time.
+
+When Staker is used for a protocol or DAO, the rewards are generally funded by protocol revenue and/or issuance of the native token from the treasury.
 
 ## Implementation details:
 
-Governance Staking can be deployed as an immutable contract with minimal governance. It does have some admin functions:
+Staker can be deployed as an immutable contract with minimal governance. It does have some admin functions:
 
 - Adding a new source of rewards
 - Changing the eligibility oracle or the emergency pause guardian
 - Overriding eligibility for a particular address
 
-Staking is compatible with existing `ERC20Votes` governance tokens. It splits voting power by creating a surrogate contract for each delegate.
+The staking token can be an `ERC20` token, including `ERC20Votes` governance tokens. Staker splits up all voting power in Staker by creating a surrogate contract for each delegate.
 
-Governance Staking distributes rewards over a fixed period of time. That gives everyone a chance to stake and minimizes discontinuities from flash staking.
+Staker distributes rewards over a fixed period of time. That gives everyone a chance to stake and minimizes discontinuities from flash staking.
 
-### Governance Staking system
+### Staking system
 
-The governance staking system accepts user stake, delegates their voting power, and distributes rewards for eligibile stakers.
+The staking system accepts user stake, delegates their voting power, and distributes rewards for eligibile stakers.
 
 ```mermaid
 
@@ -35,7 +47,7 @@ stateDiagram-v2
 
     User --> CUF: Stakes tokens
 
-    state GovernanceStaker {
+    state Staker {
         state "Key User Functions" as CUF {
             stake --> claimReward
             claimReward --> withdraw
@@ -63,8 +75,8 @@ stateDiagram-v2
     DelegationSurrogate --> Delegatee: Delegates voting power
     Admin --> CAF: e.g. governance
 
-    RewardNotifier --> GovernanceStaker: Tells Staker about new rewards
-    EarningPowerCalculator --> GovernanceStaker: Calculates eligibility
+    RewardNotifier --> Staker: Tells Staker about new rewards
+    EarningPowerCalculator --> Staker: Calculates eligibility
 
 
 ```
@@ -102,7 +114,7 @@ stateDiagram-v2
     ScoreOracle --> SOF: Updates scores
     Owner --> OF: Admin controls
     Guardian --> GF: Emergency pause
-    PF --> GovernanceStaker: Returns earning power to staking system
+    PF --> Staker: Returns earning power to staking system
 ```
 
 ## Development

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -7,7 +7,7 @@ import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {Script} from "forge-std/Script.sol";
 
 import {DeployInput} from "script/DeployInput.sol";
-import {GovernanceStakerHarness} from "test/harnesses/GovernanceStakerHarness.sol";
+import {StakerHarness} from "test/harnesses/StakerHarness.sol";
 import {IERC20Staking} from "src/interfaces/IERC20Staking.sol";
 import {INotifiableRewardReceiver} from "src/interfaces/INotifiableRewardReceiver.sol";
 import {IEarningPowerCalculator} from "src/interfaces/IEarningPowerCalculator.sol";
@@ -22,20 +22,19 @@ contract Deploy is Script, DeployInput {
     );
   }
 
-  function run() public returns (GovernanceStakerHarness) {
+  function run() public returns (StakerHarness) {
     vm.startBroadcast(deployerPrivateKey);
     // Deploy the staking contract
-    // TODO: Replace with the `ArbitrumStaker` contract once it is developed
-    GovernanceStakerHarness govStaker = new GovernanceStakerHarness(
+    StakerHarness govStaker = new StakerHarness(
       IERC20(PAYOUT_TOKEN_ADDRESS),
       IERC20Staking(STAKE_TOKEN_ADDRESS),
       IEarningPowerCalculator(address(0)),
       MAX_BUMP_TIP,
       vm.addr(deployerPrivateKey),
-      "GovernanceStakerHarness"
+      "StakerHarness"
     );
 
-    // Change GovernanceStaker admin from `msg.sender` to the Governor timelock
+    // Change Staker admin from `msg.sender` to the Governor timelock
     govStaker.setAdmin(GOVERNOR_TIMELOCK);
     vm.stopBroadcast();
 

--- a/src/extensions/StakerDelegateSurrogateVotes.sol
+++ b/src/extensions/StakerDelegateSurrogateVotes.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.8.23;
 
 import {DelegationSurrogate} from "src/DelegationSurrogate.sol";
 import {DelegationSurrogateVotes} from "src/DelegationSurrogateVotes.sol";
-import {GovernanceStaker} from "src/GovernanceStaker.sol";
+import {Staker} from "src/Staker.sol";
 import {IERC20Delegates} from "src/interfaces/IERC20Delegates.sol";
 
-/// @title GovernanceStakerDelegateSurrogateVotes
+/// @title StakerDelegateSurrogateVotes
 /// @author [ScopeLift](https://scopelift.co)
-/// @notice This contract extension adds delegation surrogates to the GovernanceStaker base
+/// @notice This contract extension adds delegation surrogates to the Staker base
 /// contract, allowing staked tokens to be delegated to a specific delegate.
-abstract contract GovernanceStakerDelegateSurrogateVotes is GovernanceStaker {
+abstract contract StakerDelegateSurrogateVotes is Staker {
   /// @notice Emitted when a surrogate contract is deployed.
   event SurrogateDeployed(address indexed delegatee, address indexed surrogate);
 
@@ -19,20 +19,20 @@ abstract contract GovernanceStakerDelegateSurrogateVotes is GovernanceStaker {
   mapping(address delegatee => DelegationSurrogate surrogate) private storedSurrogates;
 
   /// @notice Thrown if an inheritor uses a seperate staking token.
-  error GovernanceStakerDelegateSurrogateVotes__UnauthorizedToken();
+  error StakerDelegateSurrogateVotes__UnauthorizedToken();
 
   constructor(IERC20Delegates _votingToken) {
     if (address(STAKE_TOKEN) != address(_votingToken)) {
-      revert GovernanceStakerDelegateSurrogateVotes__UnauthorizedToken();
+      revert StakerDelegateSurrogateVotes__UnauthorizedToken();
     }
   }
 
-  /// @inheritdoc GovernanceStaker
+  /// @inheritdoc Staker
   function surrogates(address _delegatee) public view override returns (DelegationSurrogate) {
     return storedSurrogates[_delegatee];
   }
 
-  /// @inheritdoc GovernanceStaker
+  /// @inheritdoc Staker
   function _fetchOrDeploySurrogate(address _delegatee)
     internal
     virtual

--- a/src/extensions/StakerOnBehalf.sol
+++ b/src/extensions/StakerOnBehalf.sol
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.23;
 
-import {GovernanceStaker} from "src/GovernanceStaker.sol";
+import {Staker} from "src/Staker.sol";
 import {SignatureChecker} from "openzeppelin/utils/cryptography/SignatureChecker.sol";
 import {EIP712} from "openzeppelin/utils/cryptography/EIP712.sol";
 import {Nonces} from "openzeppelin/utils/Nonces.sol";
 
-/// @title GovernanceStakerOnBehalf
+/// @title StakerOnBehalf
 /// @author [ScopeLift](https://scopelift.co)
-/// @notice This contract extension adds signature execution functionality to the GovernanceStaker
+/// @notice This contract extension adds signature execution functionality to the Staker
 /// base contract, allowing key operations to be executed via signatures rather than requiring the
 /// owner or claimer to execute transactions directly. This includes staking, withdrawing,
 /// altering delegatees and claimers, and claiming rewards. Each operation requires a unique
 /// signature that is validated against the appropriate signer (owner or claimer) before
 /// execution.
-abstract contract GovernanceStakerOnBehalf is GovernanceStaker, EIP712, Nonces {
+abstract contract StakerOnBehalf is Staker, EIP712, Nonces {
   /// @notice Thrown when an onBehalf method is called with a deadline that has expired.
-  error GovernanceStakerOnBehalf__ExpiredDeadline();
+  error StakerOnBehalf__ExpiredDeadline();
 
   /// @notice Thrown if a caller supplies an invalid signature to a method that requires one.
-  error GovernanceStakerOnBehalf__InvalidSignature();
+  error StakerOnBehalf__InvalidSignature();
 
   /// @notice Type hash used when encoding data for `stakeOnBehalf` calls.
   bytes32 public constant STAKE_TYPEHASH = keccak256(
@@ -269,17 +269,17 @@ abstract contract GovernanceStakerOnBehalf is GovernanceStaker, EIP712, Nonces {
     );
     bool _isValidOwnerClaim =
       SignatureChecker.isValidSignatureNow(deposit.owner, _ownerHash, _signature);
-    if (!_isValidOwnerClaim) revert GovernanceStakerOnBehalf__InvalidSignature();
+    if (!_isValidOwnerClaim) revert StakerOnBehalf__InvalidSignature();
     return _claimReward(_depositId, deposit, deposit.owner);
   }
 
   /// @notice Internal helper method which reverts if the provided deadline has passed.
   /// @param _deadline The timestamp that represents when the operation should no longer be valid.
   function _revertIfPastDeadline(uint256 _deadline) internal view virtual {
-    if (block.timestamp > _deadline) revert GovernanceStakerOnBehalf__ExpiredDeadline();
+    if (block.timestamp > _deadline) revert StakerOnBehalf__ExpiredDeadline();
   }
 
-  /// @notice Internal helper method which reverts with GovernanceStaker__InvalidSignature if the
+  /// @notice Internal helper method which reverts with Staker__InvalidSignature if the
   /// signature is invalid.
   /// @param _signer Address of the signer.
   /// @param _hash Hash of the message.
@@ -290,6 +290,6 @@ abstract contract GovernanceStakerOnBehalf is GovernanceStaker, EIP712, Nonces {
     virtual
   {
     bool _isValid = SignatureChecker.isValidSignatureNow(_signer, _hash, _signature);
-    if (!_isValid) revert GovernanceStakerOnBehalf__InvalidSignature();
+    if (!_isValid) revert StakerOnBehalf__InvalidSignature();
   }
 }

--- a/src/extensions/StakerPermitAndStake.sol
+++ b/src/extensions/StakerPermitAndStake.sol
@@ -1,23 +1,23 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.23;
 
-import {GovernanceStaker} from "src/GovernanceStaker.sol";
+import {Staker} from "src/Staker.sol";
 import {IERC20Permit} from "openzeppelin/token/ERC20/extensions/IERC20Permit.sol";
 
-/// @title GovernanceStakerPermitAndStake
+/// @title StakerPermitAndStake
 /// @author [ScopeLift](https://scopelift.co)
-/// @notice This contract extension adds permit functionality to the GovernanceStaker base contract,
+/// @notice This contract extension adds permit functionality to the Staker base contract,
 /// allowing token approvals to happen via signatures rather than requiring a separate transaction.
 /// The permit functionality is used in conjunction with staking operations, improving UX by
 /// enabling users to approve and stake tokens in a single transaction.
 /// Note that this extension requires the stake token to support EIP-2612 permit functionality.
-abstract contract GovernanceStakerPermitAndStake is GovernanceStaker {
+abstract contract StakerPermitAndStake is Staker {
   /// @notice Thrown if an inheritor uses a seperate staking token.
-  error GovernanceStakerPermitAndStake__UnauthorizedToken();
+  error StakerPermitAndStake__UnauthorizedToken();
 
   constructor(IERC20Permit _permitToken) {
     if (address(STAKE_TOKEN) != address(_permitToken)) {
-      revert GovernanceStakerPermitAndStake__UnauthorizedToken();
+      revert StakerPermitAndStake__UnauthorizedToken();
     }
   }
 

--- a/src/interfaces/IEarningPowerCalculator.sol
+++ b/src/interfaces/IEarningPowerCalculator.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.23;
 
 /// @notice Interface for calculating earning power of a staker based on their delegate score in
-/// GovernanceStaker.
+/// Staker.
 interface IEarningPowerCalculator {
   function getEarningPower(uint256 _amountStaked, address _staker, address _delegatee)
     external

--- a/src/interfaces/INotifiableRewardReceiver.sol
+++ b/src/interfaces/INotifiableRewardReceiver.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.23;
 /// @title INotifiableRewardReceiver
 /// @author [ScopeLift](https://scopelift.co)
 /// @notice The communication interface between contracts that distribute rewards and the
-/// GovernanceStaker contract. In particular, said contracts only need to know the staker
+/// Staker contract. In particular, said contracts only need to know the staker
 /// implements the specified method in order to forward payouts to the staker contract. The
-/// GovernanceStaker contract receives the rewards and abstracts the distribution mechanics.
+/// Staker contract receives the rewards and abstracts the distribution mechanics.
 interface INotifiableRewardReceiver {
   /// @notice Method called to notify a reward receiver it has received a reward.
   /// @param _amount The amount of reward.

--- a/test/Staker.invariants.t.sol
+++ b/test/Staker.invariants.t.sol
@@ -4,22 +4,22 @@ pragma solidity ^0.8.23;
 import {Test} from "forge-std/Test.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 
-import {IEarningPowerCalculator} from "src/GovernanceStaker.sol";
-import {GovernanceStakerHandler} from "test/helpers/GovernanceStaker.handler.sol";
-import {GovernanceStakerHarness} from "test/harnesses/GovernanceStakerHarness.sol";
+import {IEarningPowerCalculator} from "src/Staker.sol";
+import {StakerHandler} from "test/helpers/Staker.handler.sol";
+import {StakerHarness} from "test/harnesses/StakerHarness.sol";
 import {ERC20VotesMock} from "test/mocks/MockERC20Votes.sol";
 import {ERC20Fake} from "test/fakes/ERC20Fake.sol";
 import {MockFullEarningPowerCalculator} from "test/mocks/MockFullEarningPowerCalculator.sol";
 
-contract GovernanceStakerInvariants is Test {
-  GovernanceStakerHandler public handler;
-  GovernanceStakerHarness public govStaker;
+contract StakerInvariants is Test {
+  StakerHandler public handler;
+  StakerHarness public govStaker;
   ERC20Fake rewardToken;
   ERC20VotesMock govToken;
   IEarningPowerCalculator earningPowerCalculator;
   address rewardsNotifier;
   uint256 maxBumpTip = 2e18;
-  string STAKER_NAME = "GovernanceStakerHarness";
+  string STAKER_NAME = "StakerHarness";
 
   function setUp() public {
     rewardToken = new ERC20Fake();
@@ -34,19 +34,19 @@ contract GovernanceStakerInvariants is Test {
     earningPowerCalculator = new MockFullEarningPowerCalculator();
     vm.label(address(earningPowerCalculator), "Full Earning Power Calculator");
 
-    govStaker = new GovernanceStakerHarness(
+    govStaker = new StakerHarness(
       rewardToken, govToken, earningPowerCalculator, maxBumpTip, rewardsNotifier, STAKER_NAME
     );
-    handler = new GovernanceStakerHandler(govStaker);
+    handler = new StakerHandler(govStaker);
 
     bytes4[] memory selectors = new bytes4[](7);
-    selectors[0] = GovernanceStakerHandler.stake.selector;
-    selectors[1] = GovernanceStakerHandler.validStakeMore.selector;
-    selectors[2] = GovernanceStakerHandler.validWithdraw.selector;
-    selectors[3] = GovernanceStakerHandler.warpAhead.selector;
-    selectors[4] = GovernanceStakerHandler.claimReward.selector;
-    selectors[5] = GovernanceStakerHandler.enableRewardNotifier.selector;
-    selectors[6] = GovernanceStakerHandler.notifyRewardAmount.selector;
+    selectors[0] = StakerHandler.stake.selector;
+    selectors[1] = StakerHandler.validStakeMore.selector;
+    selectors[2] = StakerHandler.validWithdraw.selector;
+    selectors[3] = StakerHandler.warpAhead.selector;
+    selectors[4] = StakerHandler.claimReward.selector;
+    selectors[5] = StakerHandler.enableRewardNotifier.selector;
+    selectors[6] = StakerHandler.notifyRewardAmount.selector;
 
     targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
 

--- a/test/gas-reports/Staker.g.sol
+++ b/test/gas-reports/Staker.g.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import {Vm, Test, stdStorage, StdStorage, console2, stdError} from "forge-std/Test.sol";
 import {GasReport} from "test/lib/GasReport.sol";
-import {GovernanceStaker} from "src/GovernanceStaker.sol";
-import {GovernanceStakerTest} from "test/GovernanceStaker.t.sol";
+import {Staker} from "src/Staker.sol";
+import {StakerTest} from "test/Staker.t.sol";
 
-contract GovernanceStakerGasReport is GovernanceStakerTest, GasReport {
+contract StakerGasReport is StakerTest, GasReport {
   function setUp() public override {
     super.setUp();
   }
@@ -25,7 +25,7 @@ contract GovernanceStakerGasReport is GovernanceStakerTest, GasReport {
   function runScenarios() public override {
     address _staker;
     address _delegatee;
-    GovernanceStaker.DepositIdentifier _depositId;
+    Staker.DepositIdentifier _depositId;
     uint256 _rewardAmount;
 
     startScenario("First stake to a new delegatee");

--- a/test/harnesses/StakerHarness.sol
+++ b/test/harnesses/StakerHarness.sol
@@ -2,11 +2,10 @@
 pragma solidity ^0.8.23;
 
 import {DelegationSurrogateVotes} from "src/DelegationSurrogateVotes.sol";
-import {GovernanceStaker} from "src/GovernanceStaker.sol";
-import {GovernanceStakerPermitAndStake} from "src/extensions/GovernanceStakerPermitAndStake.sol";
-import {GovernanceStakerOnBehalf} from "src/extensions/GovernanceStakerOnBehalf.sol";
-import {GovernanceStakerDelegateSurrogateVotes} from
-  "src/extensions/GovernanceStakerDelegateSurrogateVotes.sol";
+import {Staker} from "src/Staker.sol";
+import {StakerPermitAndStake} from "src/extensions/StakerPermitAndStake.sol";
+import {StakerOnBehalf} from "src/extensions/StakerOnBehalf.sol";
+import {StakerDelegateSurrogateVotes} from "src/extensions/StakerDelegateSurrogateVotes.sol";
 
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
@@ -16,11 +15,11 @@ import {IERC20Delegates} from "src/interfaces/IERC20Delegates.sol";
 import {IEarningPowerCalculator} from "src/interfaces/IEarningPowerCalculator.sol";
 import {DelegationSurrogate} from "src/DelegationSurrogate.sol";
 
-contract GovernanceStakerHarness is
-  GovernanceStaker,
-  GovernanceStakerPermitAndStake,
-  GovernanceStakerOnBehalf,
-  GovernanceStakerDelegateSurrogateVotes
+contract StakerHarness is
+  Staker,
+  StakerPermitAndStake,
+  StakerOnBehalf,
+  StakerDelegateSurrogateVotes
 {
   constructor(
     IERC20 _rewardsToken,
@@ -30,9 +29,9 @@ contract GovernanceStakerHarness is
     address _admin,
     string memory _name
   )
-    GovernanceStaker(_rewardsToken, _stakeToken, _earningPowerCalculator, _maxBumpTip, _admin)
-    GovernanceStakerPermitAndStake(_stakeToken)
-    GovernanceStakerDelegateSurrogateVotes(_stakeToken)
+    Staker(_rewardsToken, _stakeToken, _earningPowerCalculator, _maxBumpTip, _admin)
+    StakerPermitAndStake(_stakeToken)
+    StakerDelegateSurrogateVotes(_stakeToken)
     EIP712(_name, "1")
   {
     MAX_CLAIM_FEE = 1e18;

--- a/test/helpers/Staker.handler.sol
+++ b/test/helpers/Staker.handler.sol
@@ -6,14 +6,14 @@ import {StdCheats} from "forge-std/StdCheats.sol";
 import {StdUtils} from "forge-std/StdUtils.sol";
 import {console} from "forge-std/console.sol";
 import {AddressSet, LibAddressSet} from "../helpers/AddressSet.sol";
-import {GovernanceStaker} from "src/GovernanceStaker.sol";
+import {Staker} from "src/Staker.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 
-contract GovernanceStakerHandler is CommonBase, StdCheats, StdUtils {
+contract StakerHandler is CommonBase, StdCheats, StdUtils {
   using LibAddressSet for AddressSet;
 
   // system setup
-  GovernanceStaker public govStaker;
+  Staker public govStaker;
   IERC20 public stakeToken;
   IERC20 public rewardToken;
   address public admin;
@@ -46,7 +46,7 @@ contract GovernanceStakerHandler is CommonBase, StdCheats, StdUtils {
     _;
   }
 
-  constructor(GovernanceStaker _govStaker) {
+  constructor(Staker _govStaker) {
     govStaker = _govStaker;
     stakeToken = IERC20(address(_govStaker.STAKE_TOKEN()));
     rewardToken = IERC20(address(_govStaker.REWARD_TOKEN()));
@@ -126,8 +126,8 @@ contract GovernanceStakerHandler is CommonBase, StdCheats, StdUtils {
     _useActor(_depositors, _actorSeed);
     vm.assume(_currentActor != address(0));
     vm.assume(_depositIds[_currentActor].length > 0);
-    GovernanceStaker.DepositIdentifier _depositId =
-      GovernanceStaker.DepositIdentifier.wrap(_getActorRandDepositId(_actorDepositSeed));
+    Staker.DepositIdentifier _depositId =
+      Staker.DepositIdentifier.wrap(_getActorRandDepositId(_actorDepositSeed));
     (uint256 _balance,,,,,,) = govStaker.deposits(_depositId);
     _amount = uint256(_bound(_amount, 0, _balance));
     vm.startPrank(_currentActor);
@@ -145,8 +145,8 @@ contract GovernanceStakerHandler is CommonBase, StdCheats, StdUtils {
     _useActor(_depositors, _actorSeed);
     vm.assume(_currentActor != address(0));
     vm.assume(_depositIds[_currentActor].length > 0);
-    GovernanceStaker.DepositIdentifier _depositId =
-      GovernanceStaker.DepositIdentifier.wrap(_getActorRandDepositId(_actorDepositSeed));
+    Staker.DepositIdentifier _depositId =
+      Staker.DepositIdentifier.wrap(_getActorRandDepositId(_actorDepositSeed));
     (uint256 _balance,,,,,,) = govStaker.deposits(_depositId);
     _amount = uint256(_bound(_amount, 0, _balance));
     vm.startPrank(_currentActor);
@@ -163,8 +163,8 @@ contract GovernanceStakerHandler is CommonBase, StdCheats, StdUtils {
     _useActor(_depositors, _actorSeed);
     vm.assume(_currentActor != address(0));
     vm.assume(_depositIds[_currentActor].length > 0);
-    GovernanceStaker.DepositIdentifier _depositId =
-      GovernanceStaker.DepositIdentifier.wrap(_getActorRandDepositId(_actorDepositSeed));
+    Staker.DepositIdentifier _depositId =
+      Staker.DepositIdentifier.wrap(_getActorRandDepositId(_actorDepositSeed));
     vm.startPrank(_currentActor);
     uint256 rewardsClaimed = govStaker.claimReward(_depositId);
     vm.stopPrank();


### PR DESCRIPTION
Rename contracts from "GovernanceStaker" to simply "Staker". Note that the change is intended to impact only the contract names and associated natspec documentation. Variable names—especially in test cases—are not intended to be updated. The reason for the change is to emphasize the fact that this is a generalizable staking system that *also* supports governance as a first class citizen, however it is not strictly limited to governance staking.