### PR TITLE
[M-01] Fixes: SafeERC20 library imported but not used, bypassing critical safety checks

### DIFF
--- a/src/notifiers/MintRewardNotifier.sol
+++ b/src/notifiers/MintRewardNotifier.sol
@@ -5,7 +5,6 @@ import {INotifiableRewardReceiver, IERC20} from "src/interfaces/INotifiableRewar
 import {IMintable} from "src/interfaces/IMintable.sol";
 import {RewardTokenNotifierBase} from "src/notifiers/RewardTokenNotifierBase.sol";
 import {Ownable} from "openzeppelin/access/Ownable.sol";
-import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 
 /// @title MintRewardNotifier
 /// @author [ScopeLift](https://scopelift.co)
@@ -17,8 +16,6 @@ import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 /// well as the minter contract that will create new tokens. The minter must implement the
 /// IMintable interface and grant this contract permission to mint tokens.
 contract MintRewardNotifier is RewardTokenNotifierBase {
-  using SafeERC20 for IERC20;
-
   /// @notice Emitted when the minter contract is changed.
   /// @param oldMinter The previous contract authorized to mint reward tokens.
   /// @param newMinter The new contract authorized to mint reward tokens.
@@ -66,8 +63,9 @@ contract MintRewardNotifier is RewardTokenNotifierBase {
   }
 
   /// @inheritdoc RewardTokenNotifierBase
-  /// @dev Mints exactly rewardAmount tokens directly to the receiver using the minter contract.
-  /// The minter must have granted this contract permission to mint tokens.
+  /// @notice Mints exactly rewardAmount tokens directly to the receiver using the minter contract.
+  /// @dev The minter must have granted this contract permission to mint tokens.
+  /// @dev The call to `mint` **must revert** if it fails to provide tokens to the receiver.
   function _sendTokensToReceiver() internal virtual override {
     minter.mint(address(RECEIVER), rewardAmount);
   }

--- a/src/notifiers/RewardTokenNotifierBase.sol
+++ b/src/notifiers/RewardTokenNotifierBase.sol
@@ -41,6 +41,8 @@ abstract contract RewardTokenNotifierBase is Ownable {
   /// @notice Thrown if a caller attempts to notify rewards before the reward interval has elapsed.
   error RewardTokenNotifierBase__RewardIntervalNotElapsed();
 
+  error RewardTokenNotifierBase__InvalidParameter();
+
   /// @notice The contract that will receive reward notifications. Typically an instance of Staker.
   INotifiableRewardReceiver public immutable RECEIVER;
 
@@ -108,6 +110,8 @@ abstract contract RewardTokenNotifierBase is Ownable {
   /// @notice Internal helper method which sets a new reward amount.
   /// @param _newRewardAmount The new amount of reward tokens to distribute per notification.
   function _setRewardAmount(uint256 _newRewardAmount) internal {
+    if (_newRewardAmount == 0) revert RewardTokenNotifierBase__InvalidParameter();
+
     emit RewardAmountSet(rewardAmount, _newRewardAmount);
     rewardAmount = _newRewardAmount;
   }

--- a/src/notifiers/TransferFromRewardNotifier.sol
+++ b/src/notifiers/TransferFromRewardNotifier.sol
@@ -69,6 +69,6 @@ contract TransferFromRewardNotifier is RewardTokenNotifierBase {
   /// using transferFrom. The rewardSource must have approved this contract to spend at least
   /// rewardAmount tokens.
   function _sendTokensToReceiver() internal virtual override {
-    TOKEN.transferFrom(rewardSource, address(RECEIVER), rewardAmount);
+    TOKEN.safeTransferFrom(rewardSource, address(RECEIVER), rewardAmount);
   }
 }

--- a/src/notifiers/TransferRewardNotifier.sol
+++ b/src/notifiers/TransferRewardNotifier.sol
@@ -17,11 +17,6 @@ import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 contract TransferRewardNotifier is RewardTokenNotifierBase {
   using SafeERC20 for IERC20;
 
-  /// @notice Emitted when the owner approves an address to spend tokens.
-  /// @param spender The address being granted approval.
-  /// @param amount The amount of tokens approved for spending.
-  event Approved(address indexed spender, uint256 amount);
-
   /// @param _receiver The contract that will receive reward notifications, typically an instance
   /// of Staker.
   /// @param _initialRewardAmount The initial amount of reward tokens to be distributed per
@@ -47,7 +42,6 @@ contract TransferRewardNotifier is RewardTokenNotifierBase {
   function approve(address _spender, uint256 _amount) external {
     _checkOwner();
     TOKEN.safeIncreaseAllowance(_spender, _amount);
-    emit Approved(_spender, _amount);
   }
 
   /// @inheritdoc RewardTokenNotifierBase

--- a/src/notifiers/TransferRewardNotifier.sol
+++ b/src/notifiers/TransferRewardNotifier.sol
@@ -46,7 +46,7 @@ contract TransferRewardNotifier is RewardTokenNotifierBase {
   /// as desired.
   function approve(address _spender, uint256 _amount) external {
     _checkOwner();
-    TOKEN.approve(_spender, _amount);
+    TOKEN.safeIncreaseAllowance(_spender, _amount);
     emit Approved(_spender, _amount);
   }
 
@@ -55,6 +55,6 @@ contract TransferRewardNotifier is RewardTokenNotifierBase {
   /// using transfer. This contract must have a sufficient balance of reward tokens for the
   /// transfer to succeed.
   function _sendTokensToReceiver() internal virtual override {
-    TOKEN.transfer(address(RECEIVER), rewardAmount);
+    TOKEN.safeTransfer(address(RECEIVER), rewardAmount);
   }
 }

--- a/test/MintRewardNotifier.t.sol
+++ b/test/MintRewardNotifier.t.sol
@@ -51,6 +51,7 @@ contract Constructor is MintRewardNotifierTest {
   ) public {
     _assumeSafeOwner(_owner);
     _assumeSafeMockAddress(_receiver);
+    _initialRewardAmount = bound(_initialRewardAmount, 1, type(uint256).max);
     vm.mockCall(
       _receiver,
       abi.encodeWithSelector(INotifiableRewardReceiver.REWARD_TOKEN.selector),
@@ -74,6 +75,8 @@ contract Constructor is MintRewardNotifierTest {
   }
 
   function testFuzz_EmitsAnEventForSettingTheRewardAmount(uint256 _initialRewardAmount) public {
+    _initialRewardAmount = bound(_initialRewardAmount, 1, type(uint256).max);
+
     vm.expectEmit();
     emit RewardTokenNotifierBase.RewardAmountSet(0, _initialRewardAmount);
     new MintRewardNotifier(receiver, _initialRewardAmount, initialRewardInterval, owner, token);

--- a/test/TransferRewardNotifier.t.sol
+++ b/test/TransferRewardNotifier.t.sol
@@ -53,6 +53,7 @@ contract Constructor is TransferRewardNotifierTest {
   ) public {
     _assumeSafeOwner(_owner);
     _assumeSafeMockAddress(_receiver);
+    _initialRewardAmount = bound(_initialRewardAmount, 1, type(uint256).max);
     vm.mockCall(
       _receiver,
       abi.encodeWithSelector(INotifiableRewardReceiver.REWARD_TOKEN.selector),
@@ -71,6 +72,8 @@ contract Constructor is TransferRewardNotifierTest {
   }
 
   function testFuzz_EmitsAnEventForSettingTheRewardAmount(uint256 _initialRewardAmount) public {
+    _initialRewardAmount = bound(_initialRewardAmount, 1, type(uint256).max);
+
     vm.expectEmit();
     emit RewardTokenNotifierBase.RewardAmountSet(0, _initialRewardAmount);
     new TransferRewardNotifier(receiver, _initialRewardAmount, initialRewardInterval, owner);

--- a/test/TransferRewardNotifier.t.sol
+++ b/test/TransferRewardNotifier.t.sol
@@ -254,15 +254,6 @@ contract Approve is TransferRewardNotifierTest {
     assertEq(token.allowance(address(notifier), _spender), _amount);
   }
 
-  function testFuzz_EmitsAnApprovedEvent(address _spender, uint256 _amount) public {
-    vm.assume(_spender != address(0));
-
-    vm.expectEmit();
-    emit TransferRewardNotifier.Approved(_spender, _amount);
-    vm.prank(owner);
-    notifier.approve(_spender, _amount);
-  }
-
   function testFuzz_RevertIf_CallerIsNotOwner(address _spender, uint256 _amount, address _notOwner)
     public
   {


### PR DESCRIPTION
Call the SafeERC20 methods inside the notifier implementations

Also documents the expectation in the MintRewardNotifier that the call to `mint` must revert if it fails to provide tokens to the receiver.