### PR TITLE
[L-01] Validate that the reward amount is never set to zero

### DIFF
--- a/src/notifiers/RewardTokenNotifierBase.sol
+++ b/src/notifiers/RewardTokenNotifierBase.sol
@@ -41,6 +41,8 @@ abstract contract RewardTokenNotifierBase is Ownable {
   /// @notice Thrown if a caller attempts to notify rewards before the reward interval has elapsed.
   error RewardTokenNotifierBase__RewardIntervalNotElapsed();
 
+  error RewardTokenNotifierBase__InvalidParameter();
+
   /// @notice The contract that will receive reward notifications. Typically an instance of Staker.
   INotifiableRewardReceiver public immutable RECEIVER;
 
@@ -108,6 +110,8 @@ abstract contract RewardTokenNotifierBase is Ownable {
   /// @notice Internal helper method which sets a new reward amount.
   /// @param _newRewardAmount The new amount of reward tokens to distribute per notification.
   function _setRewardAmount(uint256 _newRewardAmount) internal {
+    if (_newRewardAmount == 0) revert RewardTokenNotifierBase__InvalidParameter();
+
     emit RewardAmountSet(rewardAmount, _newRewardAmount);
     rewardAmount = _newRewardAmount;
   }

--- a/src/notifiers/TransferRewardNotifier.sol
+++ b/src/notifiers/TransferRewardNotifier.sol
@@ -17,11 +17,6 @@ import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 contract TransferRewardNotifier is RewardTokenNotifierBase {
   using SafeERC20 for IERC20;
 
-  /// @notice Emitted when the owner approves an address to spend tokens.
-  /// @param spender The address being granted approval.
-  /// @param amount The amount of tokens approved for spending.
-  event Approved(address indexed spender, uint256 amount);
-
   /// @param _receiver The contract that will receive reward notifications, typically an instance
   /// of Staker.
   /// @param _initialRewardAmount The initial amount of reward tokens to be distributed per
@@ -47,7 +42,6 @@ contract TransferRewardNotifier is RewardTokenNotifierBase {
   function approve(address _spender, uint256 _amount) external {
     _checkOwner();
     TOKEN.safeIncreaseAllowance(_spender, _amount);
-    emit Approved(_spender, _amount);
   }
 
   /// @inheritdoc RewardTokenNotifierBase

--- a/test/MintRewardNotifier.t.sol
+++ b/test/MintRewardNotifier.t.sol
@@ -51,6 +51,7 @@ contract Constructor is MintRewardNotifierTest {
   ) public {
     _assumeSafeOwner(_owner);
     _assumeSafeMockAddress(_receiver);
+    _initialRewardAmount = bound(_initialRewardAmount, 1, type(uint256).max);
     vm.mockCall(
       _receiver,
       abi.encodeWithSelector(INotifiableRewardReceiver.REWARD_TOKEN.selector),
@@ -74,6 +75,8 @@ contract Constructor is MintRewardNotifierTest {
   }
 
   function testFuzz_EmitsAnEventForSettingTheRewardAmount(uint256 _initialRewardAmount) public {
+    _initialRewardAmount = bound(_initialRewardAmount, 1, type(uint256).max);
+
     vm.expectEmit();
     emit RewardTokenNotifierBase.RewardAmountSet(0, _initialRewardAmount);
     new MintRewardNotifier(receiver, _initialRewardAmount, initialRewardInterval, owner, token);

--- a/test/TransferRewardNotifier.t.sol
+++ b/test/TransferRewardNotifier.t.sol
@@ -53,6 +53,7 @@ contract Constructor is TransferRewardNotifierTest {
   ) public {
     _assumeSafeOwner(_owner);
     _assumeSafeMockAddress(_receiver);
+    _initialRewardAmount = bound(_initialRewardAmount, 1, type(uint256).max);
     vm.mockCall(
       _receiver,
       abi.encodeWithSelector(INotifiableRewardReceiver.REWARD_TOKEN.selector),
@@ -71,6 +72,8 @@ contract Constructor is TransferRewardNotifierTest {
   }
 
   function testFuzz_EmitsAnEventForSettingTheRewardAmount(uint256 _initialRewardAmount) public {
+    _initialRewardAmount = bound(_initialRewardAmount, 1, type(uint256).max);
+
     vm.expectEmit();
     emit RewardTokenNotifierBase.RewardAmountSet(0, _initialRewardAmount);
     new TransferRewardNotifier(receiver, _initialRewardAmount, initialRewardInterval, owner);

--- a/test/TransferRewardNotifier.t.sol
+++ b/test/TransferRewardNotifier.t.sol
@@ -254,15 +254,6 @@ contract Approve is TransferRewardNotifierTest {
     assertEq(token.allowance(address(notifier), _spender), _amount);
   }
 
-  function testFuzz_EmitsAnApprovedEvent(address _spender, uint256 _amount) public {
-    vm.assume(_spender != address(0));
-
-    vm.expectEmit();
-    emit TransferRewardNotifier.Approved(_spender, _amount);
-    vm.prank(owner);
-    notifier.approve(_spender, _amount);
-  }
-
   function testFuzz_RevertIf_CallerIsNotOwner(address _spender, uint256 _amount, address _notOwner)
     public
   {


### PR DESCRIPTION
We've implemented the zero check for the reward amount because, if it were ever set to zero, it could result in unwanted calls to `notify` that would otherwise not be possible, i.e. if the tokens/approval/minter role had been revoked from the notifier.

We opted not to implement any other suggested validations for the following reasons:

* `RECEIVER` - Because we call `REWARD_TOKEN()` on the receiver parameter passed to the constructor, this check is unneeded, as setting it to zero would already cause a revert.
* `rewardSource` and `minter` - If either of these parameters were set to `address(0)` in their respective notifiers, the call to `notify` would simply revert when called. Because the parameter must go through a governance process to be set, and can be updated by governance at any time, this is an acceptable outcome in the unlikely event of a misconfiguration.