### PR TITLE
[L-02] Implement min & max reward interval validation

### DIFF
--- a/src/notifiers/TransferRewardNotifier.sol
+++ b/src/notifiers/TransferRewardNotifier.sol
@@ -17,11 +17,6 @@ import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 contract TransferRewardNotifier is RewardTokenNotifierBase {
   using SafeERC20 for IERC20;
 
-  /// @notice Emitted when the owner approves an address to spend tokens.
-  /// @param spender The address being granted approval.
-  /// @param amount The amount of tokens approved for spending.
-  event Approved(address indexed spender, uint256 amount);
-
   /// @param _receiver The contract that will receive reward notifications, typically an instance
   /// of Staker.
   /// @param _initialRewardAmount The initial amount of reward tokens to be distributed per
@@ -47,7 +42,6 @@ contract TransferRewardNotifier is RewardTokenNotifierBase {
   function approve(address _spender, uint256 _amount) external {
     _checkOwner();
     TOKEN.safeIncreaseAllowance(_spender, _amount);
-    emit Approved(_spender, _amount);
   }
 
   /// @inheritdoc RewardTokenNotifierBase

--- a/test/TransferRewardNotifier.t.sol
+++ b/test/TransferRewardNotifier.t.sol
@@ -254,15 +254,6 @@ contract Approve is TransferRewardNotifierTest {
     assertEq(token.allowance(address(notifier), _spender), _amount);
   }
 
-  function testFuzz_EmitsAnApprovedEvent(address _spender, uint256 _amount) public {
-    vm.assume(_spender != address(0));
-
-    vm.expectEmit();
-    emit TransferRewardNotifier.Approved(_spender, _amount);
-    vm.prank(owner);
-    notifier.approve(_spender, _amount);
-  }
-
   function testFuzz_RevertIf_CallerIsNotOwner(address _spender, uint256 _amount, address _notOwner)
     public
   {


### PR DESCRIPTION
We've implemented MIN and MAX validation, which can be overriden in an inheriting contract's constructor if a wider range is required by an implementer. We've also documented the importance of setting a safe reward interval in the natspec.