### PR TITLE
add test for WithdrawBase

### DIFF
--- a/src/test/StakerTestBase.sol
+++ b/src/test/StakerTestBase.sol
@@ -185,4 +185,10 @@ abstract contract StakerTestBase is Test, PercentAssertions {
         && (!isKnownDepositor[address(_surrogate)])
     );
   }
+
+  /// @notice A test helper that assumes an address is neither zero nor the staker contract
+  function _assumeNotZeroAddressOrStaker(address _addr) internal {
+    assumeNotZeroAddress(_addr);
+    vm.assume(_addr != address(staker));
+  }
 }

--- a/src/test/StandardTestSuite.sol
+++ b/src/test/StandardTestSuite.sol
@@ -87,10 +87,11 @@ abstract contract WithdrawBase is StakerTestBase {
     vm.assume(_depositor1 != address(0) && _depositor2 != address(0) && _depositor1 != _depositor2);
     vm.assume(_depositor1 != address(staker) && _depositor2 != address(staker));
     vm.assume(_delegatee != address(0));
-    vm.assume(_amount != 0);
     vm.assume(_percentDuration1 != _percentDuration2);
 
     _amount = uint96(_boundMintAmount(_amount));
+    vm.assume(_amount != 0);
+
     _mintStakeToken(_depositor1, _amount);
     _mintStakeToken(_depositor2, _amount);
     _rewardAmount = _boundToRealisticReward(_rewardAmount);

--- a/src/test/StandardTestSuite.sol
+++ b/src/test/StandardTestSuite.sol
@@ -84,10 +84,9 @@ abstract contract WithdrawBase is StakerTestBase {
     uint256 _percentDuration1,
     uint256 _percentDuration2
   ) public {
-    vm.assume(_depositor1 != address(0) && _depositor2 != address(0) && _depositor1 != _depositor2);
-    vm.assume(_depositor1 != address(staker) && _depositor2 != address(staker));
-    vm.assume(_delegatee != address(0));
-    vm.assume(_percentDuration1 != _percentDuration2);
+    _assumeNotZeroAddressOrStaker(_depositor1);
+    _assumeNotZeroAddressOrStaker(_depositor2);
+    vm.assume(_depositor1 != _depositor2 && _delegatee != address(0));
 
     _amount = uint96(_boundMintAmount(_amount));
     vm.assume(_amount != 0);
@@ -127,8 +126,8 @@ abstract contract WithdrawBase is StakerTestBase {
     uint256 _withdrawAmount,
     uint256 _percentDuration
   ) public {
-    vm.assume(_depositor != address(0) && _delegatee != address(0) && _amount != 0);
-    vm.assume(_depositor != address(staker));
+    _assumeNotZeroAddressOrStaker(_depositor);
+    vm.assume(_delegatee != address(0));
 
     _amount = uint96(_boundMintAmount(_amount));
     _mintStakeToken(_depositor, _amount);

--- a/src/test/StandardTestSuite.sol
+++ b/src/test/StandardTestSuite.sol
@@ -96,7 +96,7 @@ abstract contract WithdrawBase is StakerTestBase {
     _mintStakeToken(_depositor2, _amount);
     _rewardAmount = _boundToRealisticReward(_rewardAmount);
     _percentDuration1 = bound(_percentDuration1, 1, 100);
-    _percentDuration2 = bound(_percentDuration2, _percentDuration1, 100);
+    _percentDuration2 = bound(_percentDuration2, 0, 100 - _percentDuration1);
 
     Staker.DepositIdentifier _depositId1 = _stake(_depositor1, _amount, _delegatee);
     Staker.DepositIdentifier _depositId2 = _stake(_depositor2, _amount, _delegatee);

--- a/src/test/StandardTestSuite.sol
+++ b/src/test/StandardTestSuite.sol
@@ -72,4 +72,86 @@ abstract contract WithdrawBase is StakerTestBase {
     assertLteWithinOneUnit(currentRewards, initialRewards);
     assertEq(_balance, _withdrawAmount);
   }
+
+  function testFuzz_WithdrawTwoUsersAfterDuration(
+    address _depositor1,
+    address _depositor2,
+    uint96 _amount,
+    address _delegatee,
+    uint256 _rewardAmount,
+    uint256 _withdrawAmount1,
+    uint256 _withdrawAmount2,
+    uint256 _percentDuration1,
+    uint256 _percentDuration2
+  ) public {
+    vm.assume(_depositor1 != address(0) && _depositor2 != address(0) && _depositor1 != _depositor2);
+    vm.assume(_depositor1 != address(staker) && _depositor2 != address(staker));
+    vm.assume(_delegatee != address(0));
+    vm.assume(_amount != 0);
+    vm.assume(_percentDuration1 != _percentDuration2);
+
+    _amount = uint96(_boundMintAmount(_amount));
+    _mintStakeToken(_depositor1, _amount);
+    _mintStakeToken(_depositor2, _amount);
+    _rewardAmount = _boundToRealisticReward(_rewardAmount);
+    _percentDuration1 = bound(_percentDuration1, 1, 100);
+    _percentDuration2 = bound(_percentDuration2, _percentDuration1, 100);
+
+    Staker.DepositIdentifier _depositId1 = _stake(_depositor1, _amount, _delegatee);
+    Staker.DepositIdentifier _depositId2 = _stake(_depositor2, _amount, _delegatee);
+
+    _notifyRewardAmount(_rewardAmount);
+
+    _jumpAheadByPercentOfRewardDuration(_percentDuration1);
+    uint256 initialRewards1 = staker.unclaimedReward(_depositId1);
+    _withdrawAmount1 = bound(_withdrawAmount1, 0, _amount);
+    _withdraw(_depositor1, _depositId1, _withdrawAmount1);
+    assertLteWithinOneUnit(staker.unclaimedReward(_depositId1), initialRewards1);
+
+    _jumpAheadByPercentOfRewardDuration(_percentDuration2);
+    uint256 initialRewards2 = staker.unclaimedReward(_depositId2);
+    _withdrawAmount2 = bound(_withdrawAmount2, 0, _amount);
+    _withdraw(_depositor2, _depositId2, _withdrawAmount2);
+    assertLteWithinOneUnit(staker.unclaimedReward(_depositId2), initialRewards2);
+
+    assertEq(STAKE_TOKEN.balanceOf(_depositor1), _withdrawAmount1);
+    assertEq(STAKE_TOKEN.balanceOf(_depositor2), _withdrawAmount2);
+  }
+
+  function testForkFuzz_ClaimRewardAndWithdrawAfterDuration(
+    address _depositor,
+    uint96 _amount,
+    address _delegatee,
+    uint256 _rewardAmount,
+    uint256 _withdrawAmount,
+    uint256 _percentDuration
+  ) public {
+    vm.assume(_depositor != address(0) && _delegatee != address(0) && _amount != 0);
+    vm.assume(_depositor != address(staker));
+
+    _amount = uint96(_boundMintAmount(_amount));
+    _mintStakeToken(_depositor, _amount);
+    _rewardAmount = _boundToRealisticReward(_rewardAmount);
+    _percentDuration = bound(_percentDuration, 1, 100);
+
+    Staker.DepositIdentifier _depositId = _stake(_depositor, _amount, _delegatee);
+    _notifyRewardAmount(_rewardAmount);
+    _jumpAheadByPercentOfRewardDuration(_percentDuration);
+
+    uint256 initialRewards = staker.unclaimedReward(_depositId);
+    uint256 initialRewardBalance = REWARD_TOKEN.balanceOf(_depositor);
+
+    vm.prank(_depositor);
+    staker.claimReward(_depositId);
+
+    uint256 rewardsReceived = REWARD_TOKEN.balanceOf(_depositor) - initialRewardBalance;
+    assertEq(staker.unclaimedReward(_depositId), 0);
+    assertEq(rewardsReceived, initialRewards);
+
+    _withdrawAmount = bound(_withdrawAmount, 0, _amount);
+    _withdraw(_depositor, _depositId, _withdrawAmount);
+
+    uint256 _balance = STAKE_TOKEN.balanceOf(_depositor);
+    assertEq(_balance, _withdrawAmount);
+  }
 }


### PR DESCRIPTION
Fixes #135 

- [x] withdraw for 2 users after some reward duration
- [x] Claim reward and withdraw

### Some findings on `modular-testing` branch
I was following the same procedure of `testForkFuzz_CorrectlyUnstakeAfterDuration()`, and found out that `_boundMintAmount()` bounds `[0, 100_000_000e18]`.
https://github.com/withtally/staker/blob/9b80e6f8b9ee002cc156466c552b221eb0e43290/src/test/StakerTestBase.sol#L65-L70

In `testForkFuzz_CorrectlyUnstakeAfterDuration()`, `_amount != 0` is assumed before bound, so there are cases when `_amount` is set to `0`, triggering overflow, underflow errors.
https://github.com/withtally/staker/blob/9b80e6f8b9ee002cc156466c552b221eb0e43290/src/test/StandardTestSuite.sol#L51-L54