### PR TITLE
refactor deploy script test to bytecode comparison

### DIFF
--- a/test/script/DeployBinaryEligibilityOracleEarningPowerCalculator.t.sol
+++ b/test/script/DeployBinaryEligibilityOracleEarningPowerCalculator.t.sol
@@ -31,18 +31,32 @@ contract DeployBinaryEligibilityOracleEarningPowerCalculatorTest is Test {
 
 contract Run is DeployBinaryEligibilityOracleEarningPowerCalculatorTest {
   function test_DeployBinaryEligibilityOracleEarningPowerCalculatorHarness() public {
-    (IEarningPowerCalculator _calculator, Staker _staker,) = deployScript.run();
-    BinaryEligibilityOracleEarningPowerCalculator _binaryEligibilityOracleCalculator =
-      BinaryEligibilityOracleEarningPowerCalculator(address(_calculator));
-    assertEq(address(_calculator), address(_staker.earningPowerCalculator()));
-    assertEq(address(_binaryEligibilityOracleCalculator.owner()), makeAddr("owner"));
-    assertEq(address(_binaryEligibilityOracleCalculator.scoreOracle()), makeAddr("scoreOracle"));
-    assertEq(_binaryEligibilityOracleCalculator.STALE_ORACLE_WINDOW(), 7 days);
-    assertEq(
-      address(_binaryEligibilityOracleCalculator.oraclePauseGuardian()),
-      makeAddr("oraclePauseGuardian")
+    (IEarningPowerCalculator _calculator,,) = deployScript.run();
+    address deployedPowerCalculator = address(_calculator);
+
+    // Encode constructor arguments with the same value as Harness
+    bytes memory args = abi.encode(
+      deployScript.owner(), // owner
+      deployScript.scoreOracle(), // scoreOracle
+      uint256(7 days), // staleOracleWindow
+      deployScript.oraclePauseGuardian(), // oraclePauseGuardian
+      uint256(50), // delegateeScoreEligibilityThreshold
+      uint256(7 days) // updateEligibilityDelay
     );
-    assertEq(_binaryEligibilityOracleCalculator.delegateeEligibilityThresholdScore(), 50);
-    assertEq(_binaryEligibilityOracleCalculator.updateEligibilityDelay(), 7 days);
+
+    // Get creation bytecode and append constructor args
+    bytes memory bytecode = abi.encodePacked(
+      vm.getCode(
+        "BinaryEligibilityOracleEarningPowerCalculator.sol:BinaryEligibilityOracleEarningPowerCalculator"
+      ),
+      args
+    );
+
+    address expectedPowerCalculator;
+    assembly {
+      expectedPowerCalculator := create(0, add(bytecode, 0x20), mload(bytecode))
+    }
+
+    assertEq(deployedPowerCalculator.code, expectedPowerCalculator.code);
   }
 }

--- a/test/script/DeployBinaryEligibilityOracleEarningPowerCalculator.t.sol
+++ b/test/script/DeployBinaryEligibilityOracleEarningPowerCalculator.t.sol
@@ -30,7 +30,24 @@ contract DeployBinaryEligibilityOracleEarningPowerCalculatorTest is Test {
 }
 
 contract Run is DeployBinaryEligibilityOracleEarningPowerCalculatorTest {
-  function test_DeployBinaryEligibilityOracleEarningPowerCalculatorHarness() public {
+  function test_DeployedCalculatorHasCorrectConfig() public {
+    (IEarningPowerCalculator _calculator, Staker _staker,) = deployScript.run();
+    BinaryEligibilityOracleEarningPowerCalculator _binaryEligibilityOracleCalculator =
+      BinaryEligibilityOracleEarningPowerCalculator(address(_calculator));
+
+    assertEq(address(_calculator), address(_staker.earningPowerCalculator()));
+    assertEq(address(_binaryEligibilityOracleCalculator.owner()), makeAddr("owner"));
+    assertEq(address(_binaryEligibilityOracleCalculator.scoreOracle()), makeAddr("scoreOracle"));
+    assertEq(_binaryEligibilityOracleCalculator.STALE_ORACLE_WINDOW(), 7 days);
+    assertEq(
+      address(_binaryEligibilityOracleCalculator.oraclePauseGuardian()),
+      makeAddr("oraclePauseGuardian")
+    );
+    assertEq(_binaryEligibilityOracleCalculator.delegateeEligibilityThresholdScore(), 50);
+    assertEq(_binaryEligibilityOracleCalculator.updateEligibilityDelay(), 7 days);
+  }
+
+  function test_DeployedCalculatorMatchesExpectedBytecode() public {
     (IEarningPowerCalculator _calculator,,) = deployScript.run();
     address deployedPowerCalculator = address(_calculator);
 

--- a/test/script/DeployTransferFromRewardNotifier.t.sol
+++ b/test/script/DeployTransferFromRewardNotifier.t.sol
@@ -27,7 +27,20 @@ contract DeployTransferFromRewardNotifierTest is Test {
 }
 
 contract Run is DeployTransferFromRewardNotifierTest {
-  function test_DeployTransferFromRewardNotifier() public {
+  function test_DeployedNotifierHasCorrectConfig() public {
+    (, Staker _staker, address[] memory _notifiers) = deployScript.run();
+
+    TransferFromRewardNotifier _transferFromNotifier = TransferFromRewardNotifier(_notifiers[0]);
+    assertEq(address(_staker), address(_transferFromNotifier.RECEIVER()));
+    assertEq(10e18, _transferFromNotifier.rewardAmount());
+    assertEq(30 days, _transferFromNotifier.rewardInterval());
+    assertEq(deployScript.notifierOwner(), _transferFromNotifier.owner());
+    assertEq(
+      address(deployScript.notifierRewardSource()), address(_transferFromNotifier.rewardSource())
+    );
+  }
+
+  function test_DeployedNotifierMatchesExpectedBytecode() public {
     (, Staker _staker, address[] memory _notifiers) = deployScript.run();
     address deployedNotifier = _notifiers[0];
 

--- a/test/script/DeployTransferRewardNotifier.t.sol
+++ b/test/script/DeployTransferRewardNotifier.t.sol
@@ -26,7 +26,17 @@ contract DeployTransferRewardNotifierTest is Test {
 }
 
 contract Run is DeployTransferRewardNotifierTest {
-  function test_DeployTransferRewardNotifier() public {
+  function test_DeployedNotifierHasCorrectConfig() public {
+    (, Staker _staker, address[] memory _notifiers) = deployScript.run();
+    TransferRewardNotifier _transferNotifier = TransferRewardNotifier(_notifiers[0]);
+
+    assertEq(address(_staker), address(_transferNotifier.RECEIVER()));
+    assertEq(10e18, _transferNotifier.rewardAmount());
+    assertEq(30 days, _transferNotifier.rewardInterval());
+    assertEq(deployScript.notifierOwner(), _transferNotifier.owner());
+  }
+
+  function test_DeployedNotifierMatchesExpectedBytecode() public {
     (, Staker _staker, address[] memory _notifiers) = deployScript.run();
     address deployedNotifier = _notifiers[0];
 


### PR DESCRIPTION
I have done some digging, and came to the conclusion that `vm.getDeployedCode()` would not work for our case to test bytecode equivalence. As the [documentation](https://book.getfoundry.sh/cheatcodes/get-deployed-code) goes:

> The main use case for this cheat code is as a shortcut to deploy stateless contracts to arbitrary addresses.

I tried comparing the output of `vm.getDeployedCode()` and the deployed code, and found out that the constructor parameters are not initialized in the output of `vm.getDeployedCode()`

Instead, `vm.getCode()` allows us to append constructor arguments with `abi.encodePacked()`. It does require some assembly, but it is provided in the documentation [here](https://book.getfoundry.sh/cheatcodes/get-code)

I will go on to refactor `DeployTransferNotifier.t.sol` and `DeployBinaryEligibilityOracleEarningPowerCalculator.t.sol` in the same way once you approve the changes currently made.