### PR TITLE
Add more integration tests

### DIFF
--- a/src/test/StakerTestBase.sol
+++ b/src/test/StakerTestBase.sol
@@ -114,7 +114,7 @@ abstract contract StakerTestBase is Test, PercentAssertions {
   }
 
   /// @notice Extension of the base stake helper that supports custom reward claimers
-  /// for AlterClaimer tests. Provides the same setup and safety checks.
+  /// for `AlterClaimer` tests. Provides the same setup and safety checks.
   /// @param _depositor The address of the depositor.
   /// @param _amount The amount to stake.
   /// @param _delegatee The address that will receive the voting power of the stake.

--- a/src/test/StakerTestBase.sol
+++ b/src/test/StakerTestBase.sol
@@ -113,6 +113,29 @@ abstract contract StakerTestBase is Test, PercentAssertions {
     _assumeSafeDepositorAndSurrogate(_depositor, _delegatee);
   }
 
+  /// @notice A test helper that wraps calling the `stake` function on the underlying Staker
+  /// contract.
+  /// @param _depositor The address of the depositor.
+  /// @param _amount The amount to stake.
+  /// @param _delegatee The address that will receive the voting power of the stake.
+  /// @param _claimer Address that will have the right to claim rewards for this stake.
+  /// @return _depositId The id of the created deposit.
+  function _stake(address _depositor, uint256 _amount, address _delegatee, address _claimer)
+    internal
+    virtual
+    returns (Staker.DepositIdentifier _depositId)
+  {
+    vm.assume(_delegatee != address(0));
+
+    vm.startPrank(_depositor);
+    STAKE_TOKEN.approve(address(staker), _amount);
+    _depositId = staker.stake(_amount, _delegatee, _claimer);
+    vm.stopPrank();
+
+    // Called after the stake so the surrogate will exist
+    _assumeSafeDepositorAndSurrogate(_depositor, _delegatee);
+  }
+
   /// @notice A test helper that wraps calling `withdraw` on the underlying Staker contract.
   /// @param _depositor The depositor that is withdrawing their stake.
   /// @param _depositId The deposit id to withdraw stake from.

--- a/src/test/StakerTestBase.sol
+++ b/src/test/StakerTestBase.sol
@@ -91,8 +91,8 @@ abstract contract StakerTestBase is Test, PercentAssertions {
     _depositId = _stake(_depositor, _boundedAmount, _delegatee);
   }
 
-  /// @notice A test helper that wraps calling the `stake` function on the underlying Staker
-  /// contract.
+  /// @notice Test helper that handles token approvals, pranking, and safety checks for staking.
+  /// Ensures consistent setup across all staking tests to reduce code duplication.
   /// @param _depositor The address of the depositor.
   /// @param _amount The amount to stake.
   /// @param _delegatee The address that will receive the voting power of the stake.
@@ -113,8 +113,8 @@ abstract contract StakerTestBase is Test, PercentAssertions {
     _assumeSafeDepositorAndSurrogate(_depositor, _delegatee);
   }
 
-  /// @notice A test helper that wraps calling the `stake` function on the underlying Staker
-  /// contract.
+  /// @notice Extension of the base stake helper that supports custom reward claimers
+  /// for AlterClaimer tests. Provides the same setup and safety checks.
   /// @param _depositor The address of the depositor.
   /// @param _amount The amount to stake.
   /// @param _delegatee The address that will receive the voting power of the stake.

--- a/src/test/StandardTestSuite.sol
+++ b/src/test/StandardTestSuite.sol
@@ -290,8 +290,9 @@ abstract contract ClaimRewardBase is StakerTestBase {
     uint256 _percentDuration
   ) public {
     _assumeNotZeroAddressOrStaker(_depositor);
-    vm.assume(_delegatee != address(0));
+    vm.assume(_delegatee != address(0) && _depositAmount != 0);
 
+    _percentDuration = bound(_percentDuration, 1, 100);
     _rewardAmount1 = _boundToRealisticReward(_rewardAmount1);
     _rewardAmount2 = _boundToRealisticReward(_rewardAmount2);
 
@@ -300,11 +301,11 @@ abstract contract ClaimRewardBase is StakerTestBase {
     Staker.DepositIdentifier _depositId = _stake(_depositor, _depositAmount, _delegatee);
 
     _notifyRewardAmount(_rewardAmount1);
-    _jumpAheadByPercentOfRewardDuration(bound(_percentDuration, 1, 100));
+    _jumpAheadByPercentOfRewardDuration(100);
 
     _rewardAmount2 = _boundToRealisticReward(_rewardAmount2);
     _notifyRewardAmount(_rewardAmount2);
-    _jumpAheadByPercentOfRewardDuration(bound(_percentDuration, 1, 100));
+    _jumpAheadByPercentOfRewardDuration(_percentDuration);
 
     uint256 _unclaimedReward = staker.unclaimedReward(_depositId);
 
@@ -314,6 +315,7 @@ abstract contract ClaimRewardBase is StakerTestBase {
     uint256 _claimedReward = REWARD_TOKEN.balanceOf(_depositor);
 
     assertEq(_claimedReward, _unclaimedReward);
+    assertLteWithinOneUnit(_claimedReward, _rewardAmount1 + _rewardAmount2 * _percentDuration / 100);
     assertEq(staker.unclaimedReward(_depositId), 0);
   }
 

--- a/src/test/StandardTestSuite.sol
+++ b/src/test/StandardTestSuite.sol
@@ -252,7 +252,7 @@ abstract contract WithdrawBase is StakerTestBase {
 }
 
 abstract contract ClaimRewardBase is StakerTestBase {
-  function testFuzz_DepositorReceivesRewardsOverSinglePeriod(
+  function testFuzz_DepositorClaimsEarnedRewardsWithinSinglePeriod(
     address _depositor,
     address _delegatee,
     uint96 _depositAmount,
@@ -284,7 +284,7 @@ abstract contract ClaimRewardBase is StakerTestBase {
     assertEq(staker.unclaimedReward(_depositId), 0);
   }
 
-  function testFuzz_DepositorReceivesRewardsOverMultiplePeriods(
+  function testFuzz_DepositorClaimsEarnedRewardsAfterMultiplePeriods(
     address _depositor,
     address _delegatee,
     uint96 _depositAmount,
@@ -319,7 +319,7 @@ abstract contract ClaimRewardBase is StakerTestBase {
     assertEq(staker.unclaimedReward(_depositId), 0);
   }
 
-  function testFuzz_DepositorClaimsRewardsWaitsAndStakesAgainOverSinglePeriod(
+  function testFuzz_DepositorClaimsRewardsWaitsAndStakesAgainWithinSinglePeriod(
     address _depositor,
     address _delegatee,
     uint96 _depositAmount,

--- a/src/test/StandardTestSuite.sol
+++ b/src/test/StandardTestSuite.sol
@@ -285,27 +285,28 @@ abstract contract ClaimRewardBase is StakerTestBase {
     address _depositor,
     address _delegatee,
     uint96 _depositAmount,
-    uint256 _rewardAmount,
+    uint256 _rewardAmount1,
+    uint256 _rewardAmount2,
     uint256 _percentDuration
   ) public {
     _assumeNotZeroAddressOrStaker(_depositor);
     vm.assume(_delegatee != address(0));
 
+    _rewardAmount1 = _boundToRealisticReward(_rewardAmount1);
+    _rewardAmount2 = _boundToRealisticReward(_rewardAmount2);
+
     _mintStakeToken(_depositor, _depositAmount);
 
-    uint256 _initialDepositorReward = REWARD_TOKEN.balanceOf(_depositor);
     Staker.DepositIdentifier _depositId = _stake(_depositor, _depositAmount, _delegatee);
 
-    _rewardAmount = _boundToRealisticReward(_rewardAmount);
-    _notifyRewardAmount(_rewardAmount);
+    _notifyRewardAmount(_rewardAmount1);
     _jumpAheadByPercentOfRewardDuration(bound(_percentDuration, 1, 100));
 
-    _rewardAmount = _boundToRealisticReward(_rewardAmount);
-    _notifyRewardAmount(_rewardAmount);
+    _rewardAmount2 = _boundToRealisticReward(_rewardAmount2);
+    _notifyRewardAmount(_rewardAmount2);
     _jumpAheadByPercentOfRewardDuration(bound(_percentDuration, 1, 100));
 
     uint256 _unclaimedReward = staker.unclaimedReward(_depositId);
-    Staker.Deposit memory _deposit = _fetchDeposit(_depositId);
 
     vm.prank(_depositor);
     staker.claimReward(_depositId);

--- a/src/test/StandardTestSuite.sol
+++ b/src/test/StandardTestSuite.sol
@@ -252,7 +252,7 @@ abstract contract WithdrawBase is StakerTestBase {
 }
 
 abstract contract ClaimRewardBase is StakerTestBase {
-  function testFuzz_DepositorClaimsEarnedRewardsWithinSinglePeriod(
+  function testFuzz_DepositorClaimsEarnedRewardsWithinASinglePeriod(
     address _depositor,
     address _delegatee,
     uint96 _depositAmount,
@@ -317,7 +317,7 @@ abstract contract ClaimRewardBase is StakerTestBase {
     assertEq(staker.unclaimedReward(_depositId), 0);
   }
 
-  function testFuzz_DepositorClaimsRewardsWaitsAndStakesAgainWithinSinglePeriod(
+  function testFuzz_DepositorClaimsRewardsWaitsAndStakesAgainWithinASinglePeriod(
     address _depositor,
     address _delegatee,
     uint96 _depositAmount,

--- a/src/test/StandardTestSuite.sol
+++ b/src/test/StandardTestSuite.sol
@@ -266,21 +266,18 @@ abstract contract ClaimRewardBase is StakerTestBase {
     _rewardAmount = _boundToRealisticReward(_rewardAmount);
     _percentDuration = bound(_percentDuration, 1, 100);
 
-    uint256 _initialDepositorReward = REWARD_TOKEN.balanceOf(_depositor);
-
     Staker.DepositIdentifier _depositId = _stake(_depositor, _depositAmount, _delegatee);
     _notifyRewardAmount(_rewardAmount);
     _jumpAheadByPercentOfRewardDuration(_percentDuration);
 
     uint256 _unclaimedReward = staker.unclaimedReward(_depositId);
-    Staker.Deposit memory _deposit = _fetchDeposit(_depositId);
 
     vm.prank(_depositor);
     staker.claimReward(_depositId);
 
-    uint256 _newDepositorReward = REWARD_TOKEN.balanceOf(_depositor);
+    uint256 _claimedReward = REWARD_TOKEN.balanceOf(_depositor);
 
-    assertEq(_newDepositorReward - _initialDepositorReward, _unclaimedReward);
+    assertEq(_claimedReward, _unclaimedReward);
     assertEq(staker.unclaimedReward(_depositId), 0);
   }
 
@@ -313,9 +310,9 @@ abstract contract ClaimRewardBase is StakerTestBase {
     vm.prank(_depositor);
     staker.claimReward(_depositId);
 
-    uint256 _newDepositorReward = REWARD_TOKEN.balanceOf(_depositor);
+    uint256 _claimedReward = REWARD_TOKEN.balanceOf(_depositor);
 
-    assertEq(_newDepositorReward - _initialDepositorReward, _unclaimedReward);
+    assertEq(_claimedReward, _unclaimedReward);
     assertEq(staker.unclaimedReward(_depositId), 0);
   }
 
@@ -329,24 +326,21 @@ abstract contract ClaimRewardBase is StakerTestBase {
     _assumeNotZeroAddressOrStaker(_depositor);
     vm.assume(_delegatee != address(0));
 
-    _mintStakeToken(_depositor, _depositAmount);
     _rewardAmount = _boundToRealisticReward(_rewardAmount);
 
-    uint256 _initialDepositorReward = REWARD_TOKEN.balanceOf(_depositor);
-
+    _mintStakeToken(_depositor, _depositAmount);
     Staker.DepositIdentifier _depositId1 = _stake(_depositor, _depositAmount, _delegatee);
     _notifyRewardAmount(_rewardAmount);
     _jumpAheadByPercentOfRewardDuration(bound(_percentDuration, 1, 100));
 
     uint256 _unclaimedReward1 = staker.unclaimedReward(_depositId1);
-    Staker.Deposit memory _deposit = _fetchDeposit(_depositId1);
 
     vm.prank(_depositor);
     staker.claimReward(_depositId1);
 
     _jumpAheadByPercentOfRewardDuration(bound(_percentDuration, 1, 100));
-    _mintStakeToken(_depositor, _depositAmount);
 
+    _mintStakeToken(_depositor, _depositAmount);
     Staker.DepositIdentifier _depositId2 = _stake(_depositor, _depositAmount, _delegatee);
     _jumpAheadByPercentOfRewardDuration(bound(_percentDuration, 1, 100));
 
@@ -358,9 +352,9 @@ abstract contract ClaimRewardBase is StakerTestBase {
     staker.claimReward(_depositId2);
     vm.stopPrank();
 
-    uint256 _newDepositorReward = REWARD_TOKEN.balanceOf(_depositor);
+    uint256 _claimedReward = REWARD_TOKEN.balanceOf(_depositor);
 
-    assertEq(_newDepositorReward - _initialDepositorReward, _unclaimedReward1 + _unclaimedReward2);
+    assertEq(_claimedReward, _unclaimedReward1 + _unclaimedReward2);
     assertEq(staker.unclaimedReward(_depositId1), 0);
     assertEq(staker.unclaimedReward(_depositId2), 0);
   }

--- a/test/test/StandardTestSuite.t.sol
+++ b/test/test/StandardTestSuite.t.sol
@@ -5,6 +5,7 @@ import {StakerTestBase, IERC20Mintable} from "../../src/test/StakerTestBase.sol"
 import {
   StakeBase,
   WithdrawBase,
+  ClaimRewardBase,
   AlterClaimerBase,
   AlterDelegateeBase
 } from "../../src/test/StandardTestSuite.sol";
@@ -42,6 +43,8 @@ contract DeployBaseHarnessTestBase is StakerTestBase {
 contract Stake is StakeBase, DeployBaseHarnessTestBase {}
 
 contract Withdraw is WithdrawBase, DeployBaseHarnessTestBase {}
+
+contract ClaimReward is ClaimRewardBase, DeployBaseHarnessTestBase {}
 
 contract AlterClaimer is AlterClaimerBase, DeployBaseHarnessTestBase {}
 

--- a/test/test/StandardTestSuite.t.sol
+++ b/test/test/StandardTestSuite.t.sol
@@ -2,7 +2,12 @@
 pragma solidity ^0.8.23;
 
 import {StakerTestBase, IERC20Mintable} from "../../src/test/StakerTestBase.sol";
-import {StakeBase, WithdrawBase, AlterDelegateeBase} from "../../src/test/StandardTestSuite.sol";
+import {
+  StakeBase,
+  WithdrawBase,
+  AlterClaimerBase,
+  AlterDelegateeBase
+} from "../../src/test/StandardTestSuite.sol";
 import {Staker} from "../../src/Staker.sol";
 import {MintRewardNotifier} from "../../src/notifiers/MintRewardNotifier.sol";
 import {DeployBaseFake} from "../fakes/DeployBaseFake.sol";
@@ -37,5 +42,7 @@ contract DeployBaseHarnessTestBase is StakerTestBase {
 contract Stake is StakeBase, DeployBaseHarnessTestBase {}
 
 contract Withdraw is WithdrawBase, DeployBaseHarnessTestBase {}
+
+contract AlterClaimer is AlterClaimerBase, DeployBaseHarnessTestBase {}
 
 contract AlterDelegatee is AlterDelegateeBase, DeployBaseHarnessTestBase {}

--- a/test/test/StandardTestSuite.t.sol
+++ b/test/test/StandardTestSuite.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.23;
 
 import {StakerTestBase, IERC20Mintable} from "../../src/test/StakerTestBase.sol";
-import {StakeBase, WithdrawBase} from "../../src/test/StandardTestSuite.sol";
+import {StakeBase, WithdrawBase, AlterDelegateeBase} from "../../src/test/StandardTestSuite.sol";
 import {Staker} from "../../src/Staker.sol";
 import {MintRewardNotifier} from "../../src/notifiers/MintRewardNotifier.sol";
 import {DeployBaseFake} from "../fakes/DeployBaseFake.sol";
@@ -37,3 +37,5 @@ contract DeployBaseHarnessTestBase is StakerTestBase {
 contract Stake is StakeBase, DeployBaseHarnessTestBase {}
 
 contract Withdraw is WithdrawBase, DeployBaseHarnessTestBase {}
+
+contract AlterDelegatee is AlterDelegateeBase, DeployBaseHarnessTestBase {}


### PR DESCRIPTION
Resolves #140 

claimReward
- [x] Depositor receives a their expected reward after a single or partial period
- [x] Depositor receives their expected reward after multiple periods
- [x] Depositor receives their reward after staking, waiting some time, and staking again within a single period
- [x] Depositor receives their reward after staking, waiting some time, and staking again after multiple periods

alterClaimer
- [x] Depositor can alter claimer before accruing rewards
- [x] Depositor can alter claimer after accruing rewards

alterDelegatee
- [x] Depositor can update their delegate